### PR TITLE
remove the unused and deprecated `multilingual` field from `book.toml`

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -1,7 +1,6 @@
 [book]
 authors = ["Lenny Peng"]
 language = "zh"
-multilingual = false
 src = "src"
 title = "Yet another Chinese rust-lang book."
 description = "又一本 rust-lang 书，Yet another Chinese rust-lang book。"


### PR DESCRIPTION
See https://github.com/szabgab/public-mdbooks/issues/10