### PR TITLE
修复章节3.2中数组声明的语法错误

### DIFF
--- a/src/programming_concepts/data_types.md
+++ b/src/programming_concepts/data_types.md
@@ -319,7 +319,7 @@ let months = ["January", "February", "March", "April", "May", "June", "July",
 
 
 ```rust
-let a: [i32, 5] = [-1, 0, 1, 2, 3];
+let a: [i32; 5] = [-1, 0, 1, 2, 3];
 ```
 
 


### PR DESCRIPTION
原文：
```rust
let a: [i32, 5] = [-1, 0, 1, 2, 3];
```
`[i32, 5]`是错误的语法，无法通过编译，应把逗号更改为分号：
```rust
let a: [i32; 5] = [-1, 0, 1, 2, 3];
```